### PR TITLE
IO-7134 Add external labels to Loki ruler

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: loki-rule-operator
 description: Install CRDs to handle Loki rules
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: v0.5.0

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
         - -enable-webhook
         {{- end }}
         - -rules-configmap={{ .Values.loki.rulesConfigMap.namespace | default .Release.Namespace }}/{{ .Values.loki.rulesConfigMap.name }}
+        {{ if .Values.externalLabels }}
+        - -external-label={{ .Values.loki.externalLabels }}
+        {{- end }}
 
         ports:
         - name: https

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -48,6 +48,7 @@ loki:
   rulesConfigMap:
     name: loki-rules
     namespace: ""
+  externalLabels: ""
 
 admissionWebhooks:
   enabled: true


### PR DESCRIPTION
We will use the external Labels to pass the environment to loki-ruler. This then allows our alerting rules to route the traffic accordingly.

related to mobimeo/infrastructure-monorepo#7134